### PR TITLE
docs: fix the example for readdirScoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Like `fs.readdir` but handling `@org/module` dirs as if they were
 a single entry.
 
 ```javascript
-const readdir = require('readdir-scoped-modules')
-const entries = await readdir('node_modules')
+const { readdirScoped } = require('@npmcli/fs')
+const entries = await readdirScoped('node_modules')
 // entries will be something like: ['a', '@org/foo', '@org/bar']
 ```
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixed the example for readdirScoped. The example was referring to another deprecated package.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
